### PR TITLE
feat: add open subscription dialogs from URL params

### DIFF
--- a/app/[locale]/subscription/page.tsx
+++ b/app/[locale]/subscription/page.tsx
@@ -66,7 +66,9 @@ export default function Subscription() {
 
     const editSubscription =
         action === "edit" && editId
-            ? rawSubscriptions.find((s) => s._id?.toString() === editId)
+            ? rawSubscriptions.find(
+                  (s) => s._id?.toString() === editId && !s.isCoSubscription,
+              )
             : undefined;
 
     const errorShownRef = useRef(false);
@@ -82,9 +84,9 @@ export default function Subscription() {
             const found = rawSubscriptions.find(
                 (s) => s._id?.toString() === editId,
             );
+            errorShownRef.current = true;
             if (!found) {
                 toast.error(t("subscriptionNotFound"));
-                errorShownRef.current = true;
             }
         }
     }, [

--- a/app/[locale]/subscription/page.tsx
+++ b/app/[locale]/subscription/page.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
+import { useSearchParams } from "next/navigation";
 import { motion } from "framer-motion";
 import { useAuth, useUser } from "@clerk/nextjs";
 import { useTranslations } from "next-intl";
 import { CircleArrowLeft, CircleArrowRight, LoaderCircle } from "lucide-react";
+import { toast } from "sonner";
 
 import {
     Select,
@@ -22,6 +24,7 @@ import { useFirstLogin } from "@/app/hooks/useFirstLogin";
 import FormattedNumber from "@/components/subscription/formatted-number";
 import CalendarCell from "@/components/subscription/calendar-cell";
 import AddSubscriptionMenuDialog from "@/components/subscription/add-subscription-menu-dialog";
+import UpdateSubscriptionDialog from "@/components/subscription/update-subscription-dialog";
 import ChartDialog from "@/components/subscription/chart-dialog";
 import CoSubscriberInvite from "@/components/subscription/co-subscriber-invite";
 import DescriptionDialog from "@/components/subscription/description-dialog";
@@ -31,6 +34,15 @@ export default function Subscription() {
     const { userId } = useAuth();
     const { user } = useUser();
     const t = useTranslations("SubscriptionPage");
+    const searchParams = useSearchParams();
+    const [action] = useState(() => searchParams.get("action"));
+    const [editId] = useState(() => searchParams.get("id"));
+
+    useEffect(() => {
+        if (action) {
+            window.history.replaceState(null, "", window.location.pathname);
+        }
+    }, [action]);
     const { year, month, calendar, handlePreviousMonth, handleNextMonth } =
         useCalendar();
     const { currenciesList, currency, setCurrency, currencyListLoading } =
@@ -43,17 +55,52 @@ export default function Subscription() {
 
     const {
         subscriptions,
+        rawSubscriptions,
+        subscriptionsLoaded,
         monthlySpend,
         updatedSubscription,
         setUpdatedSubscription,
     } = useSubscription(year, month, currency, currencyListLoading, userEmail);
     useFirstLogin();
+
+    const editSubscription =
+        action === "edit" && editId
+            ? rawSubscriptions.find((s) => s._id?.toString() === editId)
+            : undefined;
+
+    const errorShownRef = useRef(false);
+
+    useEffect(() => {
+        if (
+            action === "edit" &&
+            editId &&
+            subscriptionsLoaded &&
+            !errorShownRef.current
+        ) {
+            const found = rawSubscriptions.find(
+                (s) => s._id?.toString() === editId,
+            );
+            if (!found) {
+                toast.error(t("subscriptionNotFound"));
+                errorShownRef.current = true;
+            }
+        }
+    }, [action, editId, subscriptionsLoaded, rawSubscriptions, t]);
     const days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
     return (
         <div className="bg-subflow-900 relative flex h-full min-h-[calc(100vh-3.5rem)] w-full flex-col items-center justify-center overflow-y-auto select-none sm:min-h-[calc(100vh-7.25rem)]">
             <NewFeatureNotify />
             <DescriptionDialog />
+            {editSubscription && (
+                <UpdateSubscriptionDialog
+                    subscription={editSubscription}
+                    autoOpen={true}
+                    onSuccess={() =>
+                        setUpdatedSubscription(!updatedSubscription)
+                    }
+                />
+            )}
             {calendar.length > 0 && (
                 <div className="w-fit">
                     <div className="flex items-end justify-between pt-10 pb-2 sm:pb-4">
@@ -79,6 +126,7 @@ export default function Subscription() {
                             </span>
                             <AddSubscriptionMenuDialog
                                 userId={userId || ""}
+                                autoOpen={action === "create"}
                                 onSuccess={() =>
                                     setUpdatedSubscription(!updatedSubscription)
                                 }

--- a/app/[locale]/subscription/page.tsx
+++ b/app/[locale]/subscription/page.tsx
@@ -82,7 +82,7 @@ export default function Subscription() {
             !errorShownRef.current
         ) {
             const found = rawSubscriptions.find(
-                (s) => s._id?.toString() === editId,
+                (s) => s._id?.toString() === editId && !s.isCoSubscription,
             );
             errorShownRef.current = true;
             if (!found) {

--- a/app/[locale]/subscription/page.tsx
+++ b/app/[locale]/subscription/page.tsx
@@ -57,6 +57,7 @@ export default function Subscription() {
         subscriptions,
         rawSubscriptions,
         subscriptionsLoaded,
+        subscriptionFetchError,
         monthlySpend,
         updatedSubscription,
         setUpdatedSubscription,
@@ -75,6 +76,7 @@ export default function Subscription() {
             action === "edit" &&
             editId &&
             subscriptionsLoaded &&
+            !subscriptionFetchError &&
             !errorShownRef.current
         ) {
             const found = rawSubscriptions.find(
@@ -85,7 +87,14 @@ export default function Subscription() {
                 errorShownRef.current = true;
             }
         }
-    }, [action, editId, subscriptionsLoaded, rawSubscriptions, t]);
+    }, [
+        action,
+        editId,
+        subscriptionsLoaded,
+        subscriptionFetchError,
+        rawSubscriptions,
+        t,
+    ]);
     const days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
     return (

--- a/app/hooks/useSubscription.ts
+++ b/app/hooks/useSubscription.ts
@@ -28,14 +28,17 @@ export const useSubscription = (
         SubscriptionType[]
     >([]);
     const [subscriptionsLoaded, setSubscriptionsLoaded] = useState(false);
+    const [subscriptionFetchError, setSubscriptionFetchError] = useState(false);
 
     useEffect(() => {
         const fetchSubscriptions = async () => {
+            setSubscriptionFetchError(false);
             try {
                 const subscriptionsData = await getSubscription();
                 setRawSubscriptions(subscriptionsData);
             } catch (error) {
                 console.error("Error fetching subscriptions:", error);
+                setSubscriptionFetchError(true);
                 setRawSubscriptions([]);
             } finally {
                 setSubscriptionsLoaded(true);
@@ -176,6 +179,7 @@ export const useSubscription = (
         subscriptions,
         rawSubscriptions,
         subscriptionsLoaded,
+        subscriptionFetchError,
         monthlySpend,
         updatedSubscription,
         setUpdatedSubscription,

--- a/app/hooks/useSubscription.ts
+++ b/app/hooks/useSubscription.ts
@@ -27,6 +27,7 @@ export const useSubscription = (
     const [rawSubscriptions, setRawSubscriptions] = useState<
         SubscriptionType[]
     >([]);
+    const [subscriptionsLoaded, setSubscriptionsLoaded] = useState(false);
 
     useEffect(() => {
         const fetchSubscriptions = async () => {
@@ -36,6 +37,8 @@ export const useSubscription = (
             } catch (error) {
                 console.error("Error fetching subscriptions:", error);
                 setRawSubscriptions([]);
+            } finally {
+                setSubscriptionsLoaded(true);
             }
         };
 
@@ -171,6 +174,8 @@ export const useSubscription = (
 
     return {
         subscriptions,
+        rawSubscriptions,
+        subscriptionsLoaded,
         monthlySpend,
         updatedSubscription,
         setUpdatedSubscription,

--- a/components/subscription/add-subscription-menu-dialog.tsx
+++ b/components/subscription/add-subscription-menu-dialog.tsx
@@ -15,14 +15,16 @@ import AddSubscriptionDialog from "@/components/subscription/add-subscription-di
 interface AddSubscriptionMenuDialogProps {
     userId: string;
     onSuccess?: () => void;
+    autoOpen?: boolean;
 }
 
 export default function AddSubscriptionMenuDialog({
     userId,
     onSuccess,
+    autoOpen = false,
 }: AddSubscriptionMenuDialogProps) {
     const t = useTranslations("SubscriptionPage");
-    const [open, setOpen] = useState(false);
+    const [open, setOpen] = useState(autoOpen);
 
     const handleSuccess = () => {
         setOpen(false);

--- a/components/subscription/update-subscription-dialog.tsx
+++ b/components/subscription/update-subscription-dialog.tsx
@@ -177,11 +177,13 @@ export default function UpdateSubscriptionDialog({
                 }
             }}
         >
-            <DialogTrigger title={t("updateSubscriptionDialog.title")}>
-                <div className="hover:bg-subflow-800 flex h-6 w-6 cursor-pointer items-center justify-center rounded-sm">
-                    <Pencil size={16} strokeWidth={2} />
-                </div>
-            </DialogTrigger>
+            {!autoOpen && (
+                <DialogTrigger title={t("updateSubscriptionDialog.title")}>
+                    <div className="hover:bg-subflow-800 flex h-6 w-6 cursor-pointer items-center justify-center rounded-sm">
+                        <Pencil size={16} strokeWidth={2} />
+                    </div>
+                </DialogTrigger>
+            )}
             <DialogContent className="bg-subflow-900 border-subflow-100 rounded-2xl border-[3px] p-3 sm:p-6">
                 <DialogHeader className="text-left">
                     <div className="flex items-center justify-between">

--- a/components/subscription/update-subscription-dialog.tsx
+++ b/components/subscription/update-subscription-dialog.tsx
@@ -35,13 +35,15 @@ import CoSubscribersManager from "@/components/subscription/co-subscribers-manag
 interface UpdateSubscriptionDialogProps {
     subscription: Subscription;
     onSuccess?: () => void;
+    autoOpen?: boolean;
 }
 
 export default function UpdateSubscriptionDialog({
     subscription,
     onSuccess,
+    autoOpen = false,
 }: UpdateSubscriptionDialogProps) {
-    const [open, setOpen] = useState(false);
+    const [open, setOpen] = useState(autoOpen);
     const t = useTranslations("SubscriptionPage");
     const { currenciesList } = useCurrency();
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -144,6 +144,7 @@
         "cancel": "Cancel",
         "addSuccess": "Add Subscription Successfully",
         "addFailed": "Failed to Add Subscription",
+        "subscriptionNotFound": "Subscription not found",
         "updateSuccess": "Update Subscription Successfully",
         "deleteSuccess": "Delete Subscription Successfully",
         "subscriptionList": "Subscription List",

--- a/messages/es.json
+++ b/messages/es.json
@@ -144,6 +144,7 @@
         "cancel": "Cancelar",
         "addSuccess": "Suscripción añadida correctamente",
         "addFailed": "Error al añadir suscripción",
+        "subscriptionNotFound": "Suscripción no encontrada",
         "updateSuccess": "Suscripción actualizada correctamente",
         "deleteSuccess": "Suscripción eliminada correctamente",
         "subscriptionList": "Lista de suscripciones",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -144,6 +144,7 @@
         "cancel": "キャンセル",
         "addSuccess": "追加しました",
         "addFailed": "追加に失敗しました",
+        "subscriptionNotFound": "サブスクリプションが見つかりません",
         "updateSuccess": "更新しました",
         "deleteSuccess": "削除しました",
         "subscriptionList": "サブスク一覧",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -144,6 +144,7 @@
         "cancel": "取消",
         "addSuccess": "成功新增訂閱",
         "addFailed": "新增訂閱失敗",
+        "subscriptionNotFound": "找不到此訂閱",
         "updateSuccess": "成功更新訂閱",
         "deleteSuccess": "成功刪除訂閱",
         "subscriptionList": "訂閱清單",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate UI/state changes: introduces URL-driven dialog auto-opening and new subscription-loading/error flags that affect when toasts and edit flows trigger.
> 
> **Overview**
> Enables deep-linking into the subscription page by reading `action`/`id` query params to **auto-open** dialogs: `action=create` opens `AddSubscriptionMenuDialog`, and `action=edit&id=...` opens `UpdateSubscriptionDialog` for the matching non-co-subscription.
> 
> `useSubscription` now exposes `rawSubscriptions` plus `subscriptionsLoaded`/`subscriptionFetchError` so the page can show a localized toast when an `edit` link references a missing subscription (and it clears the query params after processing). Adds `subscriptionNotFound` translations across locales and updates both dialog components to support an `autoOpen` prop and hide the edit trigger when auto-opened.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23a592a6fc86018be1ada05b6eccf8a2e08f3b3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->