### PR TITLE
feat: add API key management UI and backend

### DIFF
--- a/app/actions/api-key.ts
+++ b/app/actions/api-key.ts
@@ -19,11 +19,6 @@ export async function createApiKey(name: string) {
     const db = await connectToDatabase();
     const ApiKey = getApiKeyModel(db);
 
-    const existingCount = await ApiKey.countDocuments({ userId });
-    if (existingCount >= MAX_API_KEYS_PER_USER) {
-        return { error: "LIMIT_REACHED" as const };
-    }
-
     const plainKey = generateApiKey();
     const keyHash = hashApiKey(plainKey);
     const keyPrefix = getKeyPrefix(plainKey);
@@ -34,8 +29,13 @@ export async function createApiKey(name: string) {
         keyHash,
         userId,
     });
-
     await apiKey.save();
+
+    const currentCount = await ApiKey.countDocuments({ userId });
+    if (currentCount > MAX_API_KEYS_PER_USER) {
+        await ApiKey.deleteOne({ _id: apiKey._id });
+        return { error: "LIMIT_REACHED" as const };
+    }
 
     return {
         id: apiKey._id.toString(),

--- a/app/actions/api-key.ts
+++ b/app/actions/api-key.ts
@@ -1,0 +1,75 @@
+"use server";
+
+import { connectToDatabase } from "@/lib/mongodb";
+import { getApiKeyModel } from "@/models/ApiKey";
+import { generateApiKey, hashApiKey, getKeyPrefix } from "@/lib/api-key";
+import { requireAuth } from "@/app/actions/action";
+
+const API_KEY_NAME_MAX_LENGTH = 50;
+const MAX_API_KEYS_PER_USER = 5;
+
+export async function createApiKey(name: string) {
+    const userId = await requireAuth();
+
+    const trimmedName = name.trim();
+    if (!trimmedName || trimmedName.length > API_KEY_NAME_MAX_LENGTH) {
+        return { error: "INVALID_NAME" as const };
+    }
+
+    const db = await connectToDatabase();
+    const ApiKey = getApiKeyModel(db);
+
+    const existingCount = await ApiKey.countDocuments({ userId });
+    if (existingCount >= MAX_API_KEYS_PER_USER) {
+        return { error: "LIMIT_REACHED" as const };
+    }
+
+    const plainKey = generateApiKey();
+    const keyHash = hashApiKey(plainKey);
+    const keyPrefix = getKeyPrefix(plainKey);
+
+    const apiKey = new ApiKey({
+        name: trimmedName,
+        keyPrefix,
+        keyHash,
+        userId,
+    });
+
+    await apiKey.save();
+
+    return {
+        id: apiKey._id.toString(),
+        name: apiKey.name,
+        keyPrefix: apiKey.keyPrefix,
+        secretKey: plainKey,
+        createdAt: apiKey.createdAt,
+    };
+}
+
+export async function listApiKeys() {
+    const userId = await requireAuth();
+
+    const db = await connectToDatabase();
+    const ApiKey = getApiKeyModel(db);
+
+    const apiKeys = await ApiKey.find({ userId })
+        .select("_id name keyPrefix createdAt lastUsedAt")
+        .sort({ createdAt: -1 });
+
+    return JSON.parse(JSON.stringify(apiKeys));
+}
+
+export async function revokeApiKey(id: string) {
+    const userId = await requireAuth();
+
+    const db = await connectToDatabase();
+    const ApiKey = getApiKeyModel(db);
+
+    const result = await ApiKey.deleteOne({ _id: id, userId });
+
+    if (result.deletedCount === 0) {
+        return { error: "NOT_FOUND" as const };
+    }
+
+    return { message: "API Key revoked successfully" };
+}

--- a/components/more-menu/api-key-dialog.tsx
+++ b/components/more-menu/api-key-dialog.tsx
@@ -1,0 +1,283 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useTranslations } from "next-intl";
+import { KeyRound, LoaderCircle, Copy, Check, Trash2 } from "lucide-react";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from "@/components/ui/dialog";
+import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { toast } from "sonner";
+
+import { createApiKey, listApiKeys, revokeApiKey } from "@/app/actions/api-key";
+
+export interface ApiKeyDialogProps {
+    setDropdownMenuOpen: (open: boolean) => void;
+}
+
+interface ApiKeyItem {
+    _id: string;
+    name: string;
+    keyPrefix: string;
+    lastUsedAt?: string;
+    createdAt: string;
+}
+
+export default function ApiKeyDialog({
+    setDropdownMenuOpen,
+}: ApiKeyDialogProps) {
+    const t = useTranslations("MoreMenu.apiKeyDialog");
+    const [open, setOpen] = useState(false);
+
+    const [keyName, setKeyName] = useState("");
+    const [apiKeys, setApiKeys] = useState<ApiKeyItem[]>([]);
+    const [createdKey, setCreatedKey] = useState<string | null>(null);
+    const [creating, setCreating] = useState(false);
+    const [loading, setLoading] = useState(false);
+    const [copied, setCopied] = useState(false);
+    const [deletingId, setDeletingId] = useState<string | null>(null);
+
+    const fetchApiKeys = useCallback(async () => {
+        setLoading(true);
+        try {
+            const keys = await listApiKeys();
+            setApiKeys(keys);
+        } catch {
+            toast.error(t("fetchFailed"));
+        } finally {
+            setLoading(false);
+        }
+    }, [t]);
+
+    useEffect(() => {
+        if (open) {
+            fetchApiKeys();
+            setCreatedKey(null);
+            setKeyName("");
+            setCopied(false);
+        }
+    }, [open, fetchApiKeys]);
+
+    const handleCreate = async () => {
+        if (creating || !keyName.trim()) return;
+        setCreating(true);
+        try {
+            const result = await createApiKey(keyName.trim());
+            if ("error" in result) {
+                if (result.error === "LIMIT_REACHED") {
+                    toast.error(t("limitReached"));
+                } else {
+                    toast.error(t("createFailed"));
+                }
+                return;
+            }
+            setCreatedKey(result.secretKey);
+            setKeyName("");
+            await fetchApiKeys();
+            toast.success(t("createSuccess"));
+        } catch {
+            toast.error(t("createFailed"));
+        } finally {
+            setCreating(false);
+        }
+    };
+
+    const handleCopy = async () => {
+        if (!createdKey) return;
+        await navigator.clipboard.writeText(createdKey);
+        setCopied(true);
+        toast.success(t("copied"));
+        setTimeout(() => setCopied(false), 2000);
+    };
+
+    const handleRevoke = async (id: string) => {
+        setDeletingId(id);
+        try {
+            const result = await revokeApiKey(id);
+            if ("error" in result) {
+                toast.error(t("revokeFailed"));
+                return;
+            }
+            setApiKeys((prev) => prev.filter((k) => k._id !== id));
+            toast.success(t("revokeSuccess"));
+        } catch {
+            toast.error(t("revokeFailed"));
+        } finally {
+            setDeletingId(null);
+        }
+    };
+
+    const formatDate = (dateStr: string) => {
+        const date = new Date(dateStr);
+        return date.toLocaleDateString(undefined, {
+            year: "numeric",
+            month: "short",
+            day: "numeric",
+        });
+    };
+
+    return (
+        <Dialog
+            open={open}
+            onOpenChange={(open) => {
+                setOpen(open);
+                if (!open) {
+                    setDropdownMenuOpen(false);
+                }
+            }}
+        >
+            <DialogTrigger title="API Keys">
+                <DropdownMenuItem
+                    className="cursor-pointer"
+                    onSelect={(e) => {
+                        e.preventDefault();
+                        setOpen(true);
+                    }}
+                >
+                    <KeyRound
+                        strokeWidth={2.8}
+                        className="h-5 w-5 text-black"
+                    />
+                    <span>{t("title")}</span>
+                </DropdownMenuItem>
+            </DialogTrigger>
+            <DialogContent className="bg-subflow-900 border-subflow-100 w-120 rounded-2xl border-[3px] p-3 select-none sm:p-4">
+                <DialogHeader className="text-left">
+                    <DialogTitle className="text-subflow-50 text-lg tracking-widest">
+                        {t("title")}
+                    </DialogTitle>
+                    <DialogDescription className="text-subflow-300 text-xs tracking-widest sm:text-sm">
+                        {t("description")}
+                    </DialogDescription>
+
+                    {/* Created Key Display */}
+                    {createdKey && (
+                        <div className="bg-subflow-800 border-subflow-500 mt-2 rounded-lg border p-3">
+                            <p className="text-subflow-200 mb-1 text-xs tracking-widest">
+                                {t("createdKeyWarning")}
+                            </p>
+                            <div className="bg-subflow-700 mt-2 flex items-center gap-2 rounded-lg px-2 py-2">
+                                <code className="text-subflow-50 flex-1 overflow-x-auto text-xs break-all select-text">
+                                    {createdKey}
+                                </code>
+                                <button
+                                    onClick={handleCopy}
+                                    className="text-subflow-200 hover:text-subflow-50 cursor-pointer transition-colors"
+                                >
+                                    {copied ? (
+                                        <Check size={16} />
+                                    ) : (
+                                        <Copy size={16} />
+                                    )}
+                                </button>
+                            </div>
+                        </div>
+                    )}
+
+                    {/* Create New Key */}
+                    <div className="mt-2 flex gap-2">
+                        <Input
+                            type="text"
+                            placeholder={t("namePlaceholder")}
+                            maxLength={50}
+                            className="text-subflow-800 bg-subflow-100 h-10 flex-1 rounded-md text-xs tracking-widest sm:text-base"
+                            value={keyName}
+                            onChange={(e) => setKeyName(e.target.value)}
+                            onKeyDown={(e) => {
+                                if (e.key === "Enter") handleCreate();
+                            }}
+                        />
+                        <button
+                            className={`bg-subflow-600 text-subflow-50 h-10 rounded-md px-4 text-xs tracking-widest sm:text-base ${
+                                creating || !keyName.trim()
+                                    ? "cursor-not-allowed opacity-50"
+                                    : "cursor-pointer"
+                            }`}
+                            onClick={handleCreate}
+                            disabled={creating || !keyName.trim()}
+                        >
+                            {creating ? (
+                                <LoaderCircle
+                                    className="animate-spin"
+                                    size={18}
+                                    strokeWidth={3}
+                                />
+                            ) : (
+                                t("create")
+                            )}
+                        </button>
+                    </div>
+
+                    {/* Key List */}
+                    <div className="custom-scrollbar mt-3 max-h-60 overflow-y-auto">
+                        {loading ? (
+                            <div className="flex items-center justify-center py-4">
+                                <LoaderCircle
+                                    className="text-subflow-300 animate-spin"
+                                    size={24}
+                                    strokeWidth={3}
+                                />
+                            </div>
+                        ) : apiKeys.length === 0 ? (
+                            <div className="border-subflow-500 flex flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed py-8">
+                                <KeyRound
+                                    className="text-subflow-300"
+                                    size={20}
+                                    strokeWidth={2.2}
+                                />
+                                <p className="text-subflow-400 text-center text-sm tracking-widest">
+                                    {t("noKeys")}
+                                </p>
+                            </div>
+                        ) : (
+                            <div className="flex flex-col gap-2">
+                                {apiKeys.map((key) => (
+                                    <div
+                                        key={key._id}
+                                        className="bg-subflow-800 flex items-center justify-between rounded-lg px-3 py-2"
+                                    >
+                                        <div className="text-subflow-50 min-w-0 flex-1">
+                                            <p className="truncate text-sm tracking-widest">
+                                                {key.name}
+                                            </p>
+                                            <div className="flex items-center gap-2 text-xs">
+                                                <code>{key.keyPrefix}</code>
+                                                <span>·</span>
+                                                <code>
+                                                    {formatDate(key.createdAt)}
+                                                </code>
+                                            </div>
+                                        </div>
+                                        <button
+                                            onClick={() =>
+                                                handleRevoke(key._id)
+                                            }
+                                            disabled={deletingId === key._id}
+                                            className="text-subflow-400 ml-2 cursor-pointer transition-colors hover:text-red-400"
+                                        >
+                                            {deletingId === key._id ? (
+                                                <LoaderCircle
+                                                    className="animate-spin"
+                                                    size={16}
+                                                    strokeWidth={3}
+                                                />
+                                            ) : (
+                                                <Trash2 size={16} />
+                                            )}
+                                        </button>
+                                    </div>
+                                ))}
+                            </div>
+                        )}
+                    </div>
+                </DialogHeader>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/components/more-menu/more-menu.tsx
+++ b/components/more-menu/more-menu.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import EmailNotifyDialog from "@/components/more-menu/email-notify-dialog";
 import PreferencesDialog from "@/components/more-menu/preferences-dialog";
+import ApiKeyDialog from "@/components/more-menu/api-key-dialog";
 
 export default function MoreMenu() {
     const [open, setOpen] = useState(false);
@@ -29,6 +30,7 @@ export default function MoreMenu() {
             >
                 <EmailNotifyDialog setDropdownMenuOpen={setOpen} />
                 <PreferencesDialog setDropdownMenuOpen={setOpen} />
+                <ApiKeyDialog setDropdownMenuOpen={setOpen} />
             </DropdownMenuContent>
         </DropdownMenu>
     );

--- a/lib/api-key.ts
+++ b/lib/api-key.ts
@@ -1,0 +1,16 @@
+import { randomBytes, createHash } from "crypto";
+
+const API_KEY_PREFIX = "sk_sf_";
+
+export function generateApiKey(): string {
+    const randomPart = randomBytes(32).toString("hex");
+    return `${API_KEY_PREFIX}${randomPart}`;
+}
+
+export function hashApiKey(key: string): string {
+    return createHash("sha256").update(key).digest("hex");
+}
+
+export function getKeyPrefix(key: string): string {
+    return key.substring(0, API_KEY_PREFIX.length + 8) + "...";
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -236,6 +236,21 @@
             "saveSettings": "Save Settings",
             "savingSettings": "Saving Settings",
             "preferencesSaved": "Preferences Saved Successfully"
+        },
+        "apiKeyDialog": {
+            "title": "API Keys",
+            "description": "Generate API keys to access Subflow from other services.",
+            "namePlaceholder": "Enter API key name",
+            "create": "Create",
+            "createdKeyWarning": "Make sure to copy your API key now. You won't be able to see it again!",
+            "copied": "Copied to clipboard",
+            "createSuccess": "API Key created successfully",
+            "createFailed": "Failed to create API Key",
+            "revokeSuccess": "API Key revoked successfully",
+            "revokeFailed": "Failed to revoke API Key",
+            "fetchFailed": "Failed to fetch API Keys",
+            "noKeys": "No API keys yet",
+            "limitReached": "Maximum of 5 API keys reached"
         }
     },
     "NotFoundPage": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -236,6 +236,21 @@
             "saveSettings": "Guardar ajustes",
             "savingSettings": "Guardando ajustes",
             "preferencesSaved": "Preferencias guardadas correctamente"
+        },
+        "apiKeyDialog": {
+            "title": "Claves API",
+            "description": "Genera claves API para acceder a Subflow desde otros servicios.",
+            "namePlaceholder": "Introduce el nombre de la clave API",
+            "create": "Crear",
+            "createdKeyWarning": "¡Asegúrate de copiar tu clave API ahora. No podrás verla de nuevo!",
+            "copied": "Copiado al portapapeles",
+            "createSuccess": "Clave API creada correctamente",
+            "createFailed": "Error al crear la clave API",
+            "revokeSuccess": "Clave API revocada correctamente",
+            "revokeFailed": "Error al revocar la clave API",
+            "fetchFailed": "Error al obtener las claves API",
+            "noKeys": "Aún no hay claves API",
+            "limitReached": "Máximo de 5 claves API alcanzado"
         }
     },
     "NotFoundPage": {

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -236,6 +236,21 @@
             "saveSettings": "設定を保存",
             "savingSettings": "設定を保存中",
             "preferencesSaved": "プリファレンスを保存しました"
+        },
+        "apiKeyDialog": {
+            "title": "API Keys",
+            "description": "他のサービスから Subflow にアクセスするための API キーを生成します。",
+            "namePlaceholder": "API キー名を入力",
+            "create": "作成",
+            "createdKeyWarning": "API キーを今すぐコピーしてください。再度表示することはできません！",
+            "copied": "クリップボードにコピーしました",
+            "createSuccess": "API キーを作成しました",
+            "createFailed": "API キーの作成に失敗しました",
+            "revokeSuccess": "API キーを取り消しました",
+            "revokeFailed": "API キーの取り消しに失敗しました",
+            "fetchFailed": "API キーの取得に失敗しました",
+            "noKeys": "まだ API キーがありません",
+            "limitReached": "API キーの上限（最大5個）に達しました"
         }
     },
     "NotFoundPage": {

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -236,6 +236,21 @@
             "saveSettings": "儲存設定",
             "savingSettings": "儲存設定中",
             "preferencesSaved": "成功儲存偏好設定"
+        },
+        "apiKeyDialog": {
+            "title": "API Keys",
+            "description": "生成 API Key 以便從其他服務存取 Subflow。",
+            "namePlaceholder": "請輸入 API Key 名稱",
+            "create": "建立",
+            "createdKeyWarning": "請立即複製您的 API Key，之後將無法再次查看！",
+            "copied": "已複製到剪貼簿",
+            "createSuccess": "成功建立 API Key",
+            "createFailed": "建立 API Key 失敗",
+            "revokeSuccess": "成功刪除 API Key",
+            "revokeFailed": "刪除 API Key 失敗",
+            "fetchFailed": "取得 API Key 列表失敗",
+            "noKeys": "尚未建立 API Key",
+            "limitReached": "已達 API Key 上限（最多 5 組）"
         }
     },
     "NotFoundPage": {

--- a/models/ApiKey.ts
+++ b/models/ApiKey.ts
@@ -1,0 +1,32 @@
+import { Connection, Schema, Document } from "mongoose";
+
+interface IApiKey extends Document {
+    name: string;
+    keyPrefix: string;
+    keyHash: string;
+    userId: string;
+    lastUsedAt?: Date;
+}
+
+export const ApiKeySchema = new Schema<IApiKey>(
+    {
+        name: { type: String, required: true, maxlength: 50 },
+        keyPrefix: { type: String, required: true },
+        keyHash: { type: String, required: true },
+        userId: { type: String, required: true },
+
+        lastUsedAt: { type: Date },
+    },
+    {
+        timestamps: { createdAt: true, updatedAt: false },
+    },
+);
+
+ApiKeySchema.index({ userId: 1 });
+ApiKeySchema.index({ keyHash: 1 }, { unique: true });
+
+export const getApiKeyModel = (db: Connection) => {
+    return (
+        db.models.ApiKey || db.model<IApiKey>("ApiKey", ApiKeySchema, "apikeys")
+    );
+};


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new credential generation/storage flows (API keys) and a new MongoDB collection, so mistakes could impact account security or data integrity despite keys being stored hashed and scoped per user.
> 
> **Overview**
> Adds **API key management** end-to-end: server actions to `createApiKey`, `listApiKeys`, and `revokeApiKey`, backed by a new `ApiKey` Mongoose model that stores only a SHA-256 hash plus a display prefix (with a per-user limit of 5 keys).
> 
> Exposes this in the UI via a new `ApiKeyDialog` entry in the More menu, supporting create/copy-once, list, and revoke flows with i18n strings added across `en/es/ja/zh`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cd7aa12ac5db366bdbd6b59b5134a3b39d95f88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->