### PR TITLE
feat: add auto-open for API key and delete dialogs

### DIFF
--- a/app/[locale]/subscription/page.tsx
+++ b/app/[locale]/subscription/page.tsx
@@ -25,6 +25,7 @@ import FormattedNumber from "@/components/subscription/formatted-number";
 import CalendarCell from "@/components/subscription/calendar-cell";
 import AddSubscriptionMenuDialog from "@/components/subscription/add-subscription-menu-dialog";
 import UpdateSubscriptionDialog from "@/components/subscription/update-subscription-dialog";
+import DeleteSubscriptionDialog from "@/components/subscription/delete-subscription-dialog";
 import ChartDialog from "@/components/subscription/chart-dialog";
 import CoSubscriberInvite from "@/components/subscription/co-subscriber-invite";
 import DescriptionDialog from "@/components/subscription/description-dialog";
@@ -71,11 +72,43 @@ export default function Subscription() {
               )
             : undefined;
 
+    const deleteSubscription =
+        action === "delete" && editId
+            ? rawSubscriptions.find(
+                  (s) => s._id?.toString() === editId && !s.isCoSubscription,
+              )
+            : undefined;
+
     const errorShownRef = useRef(false);
 
     useEffect(() => {
         if (
             action === "edit" &&
+            editId &&
+            subscriptionsLoaded &&
+            !subscriptionFetchError &&
+            !errorShownRef.current
+        ) {
+            const found = rawSubscriptions.find(
+                (s) => s._id?.toString() === editId && !s.isCoSubscription,
+            );
+            errorShownRef.current = true;
+            if (!found) {
+                toast.error(t("subscriptionNotFound"));
+            }
+        }
+    }, [
+        action,
+        editId,
+        subscriptionsLoaded,
+        subscriptionFetchError,
+        rawSubscriptions,
+        t,
+    ]);
+
+    useEffect(() => {
+        if (
+            action === "delete" &&
             editId &&
             subscriptionsLoaded &&
             !subscriptionFetchError &&
@@ -106,6 +139,15 @@ export default function Subscription() {
             {editSubscription && (
                 <UpdateSubscriptionDialog
                     subscription={editSubscription}
+                    autoOpen={true}
+                    onSuccess={() =>
+                        setUpdatedSubscription(!updatedSubscription)
+                    }
+                />
+            )}
+            {deleteSubscription && (
+                <DeleteSubscriptionDialog
+                    subscription={deleteSubscription}
                     autoOpen={true}
                     onSuccess={() =>
                         setUpdatedSubscription(!updatedSubscription)

--- a/app/[locale]/subscription/page.tsx
+++ b/app/[locale]/subscription/page.tsx
@@ -82,45 +82,23 @@ export default function Subscription() {
     const errorShownRef = useRef(false);
 
     useEffect(() => {
-        if (
-            action === "edit" &&
+        const shouldCheckNotFound =
+            (action === "edit" || action === "delete") &&
             editId &&
             subscriptionsLoaded &&
             !subscriptionFetchError &&
-            !errorShownRef.current
-        ) {
-            const found = rawSubscriptions.find(
-                (s) => s._id?.toString() === editId && !s.isCoSubscription,
-            );
-            errorShownRef.current = true;
-            if (!found) {
-                toast.error(t("subscriptionNotFound"));
-            }
-        }
-    }, [
-        action,
-        editId,
-        subscriptionsLoaded,
-        subscriptionFetchError,
-        rawSubscriptions,
-        t,
-    ]);
+            !errorShownRef.current;
 
-    useEffect(() => {
-        if (
-            action === "delete" &&
-            editId &&
-            subscriptionsLoaded &&
-            !subscriptionFetchError &&
-            !errorShownRef.current
-        ) {
-            const found = rawSubscriptions.find(
-                (s) => s._id?.toString() === editId && !s.isCoSubscription,
-            );
-            errorShownRef.current = true;
-            if (!found) {
-                toast.error(t("subscriptionNotFound"));
-            }
+        if (!shouldCheckNotFound) {
+            return;
+        }
+
+        const found = rawSubscriptions.find(
+            (s) => s._id?.toString() === editId && !s.isCoSubscription,
+        );
+        errorShownRef.current = true;
+        if (!found) {
+            toast.error(t("subscriptionNotFound"));
         }
     }, [
         action,

--- a/components/more-menu/api-key-dialog.tsx
+++ b/components/more-menu/api-key-dialog.tsx
@@ -37,12 +37,6 @@ export default function ApiKeyDialog({
     const t = useTranslations("MoreMenu.apiKeyDialog");
     const [open, setOpen] = useState(autoOpen);
 
-    useEffect(() => {
-        if (autoOpen) {
-            setOpen(true);
-        }
-    }, [autoOpen]);
-
     const [keyName, setKeyName] = useState("");
     const [apiKeys, setApiKeys] = useState<ApiKeyItem[]>([]);
     const [createdKey, setCreatedKey] = useState<string | null>(null);

--- a/components/more-menu/api-key-dialog.tsx
+++ b/components/more-menu/api-key-dialog.tsx
@@ -19,6 +19,7 @@ import { createApiKey, listApiKeys, revokeApiKey } from "@/app/actions/api-key";
 
 export interface ApiKeyDialogProps {
     setDropdownMenuOpen: (open: boolean) => void;
+    autoOpen?: boolean;
 }
 
 interface ApiKeyItem {
@@ -31,9 +32,16 @@ interface ApiKeyItem {
 
 export default function ApiKeyDialog({
     setDropdownMenuOpen,
+    autoOpen = false,
 }: ApiKeyDialogProps) {
     const t = useTranslations("MoreMenu.apiKeyDialog");
-    const [open, setOpen] = useState(false);
+    const [open, setOpen] = useState(autoOpen);
+
+    useEffect(() => {
+        if (autoOpen) {
+            setOpen(true);
+        }
+    }, [autoOpen]);
 
     const [keyName, setKeyName] = useState("");
     const [apiKeys, setApiKeys] = useState<ApiKeyItem[]>([]);

--- a/components/more-menu/more-menu.tsx
+++ b/components/more-menu/more-menu.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import { useSearchParams } from "next/navigation";
 import { CircleEllipsis } from "lucide-react";
 import {
     DropdownMenu,
@@ -12,7 +13,23 @@ import PreferencesDialog from "@/components/more-menu/preferences-dialog";
 import ApiKeyDialog from "@/components/more-menu/api-key-dialog";
 
 export default function MoreMenu() {
-    const [open, setOpen] = useState(false);
+    const searchParams = useSearchParams();
+    const menuAction = searchParams.get("menu");
+    const autoOpenApiKey = menuAction === "api-key";
+
+    const [open, setOpen] = useState(autoOpenApiKey);
+
+    useEffect(() => {
+        if (autoOpenApiKey) {
+            setOpen(true);
+        }
+    }, [autoOpenApiKey]);
+
+    useEffect(() => {
+        if (menuAction) {
+            window.history.replaceState(null, "", window.location.pathname);
+        }
+    }, [menuAction]);
 
     return (
         <DropdownMenu open={open} onOpenChange={setOpen}>
@@ -30,7 +47,10 @@ export default function MoreMenu() {
             >
                 <EmailNotifyDialog setDropdownMenuOpen={setOpen} />
                 <PreferencesDialog setDropdownMenuOpen={setOpen} />
-                <ApiKeyDialog setDropdownMenuOpen={setOpen} />
+                <ApiKeyDialog
+                    setDropdownMenuOpen={setOpen}
+                    autoOpen={menuAction === "api-key"}
+                />
             </DropdownMenuContent>
         </DropdownMenu>
     );

--- a/components/more-menu/more-menu.tsx
+++ b/components/more-menu/more-menu.tsx
@@ -14,16 +14,10 @@ import ApiKeyDialog from "@/components/more-menu/api-key-dialog";
 
 export default function MoreMenu() {
     const searchParams = useSearchParams();
-    const menuAction = searchParams.get("menu");
+    const [menuAction] = useState(() => searchParams.get("menu"));
     const autoOpenApiKey = menuAction === "api-key";
 
     const [open, setOpen] = useState(autoOpenApiKey);
-
-    useEffect(() => {
-        if (autoOpenApiKey) {
-            setOpen(true);
-        }
-    }, [autoOpenApiKey]);
 
     useEffect(() => {
         if (menuAction) {
@@ -49,7 +43,7 @@ export default function MoreMenu() {
                 <PreferencesDialog setDropdownMenuOpen={setOpen} />
                 <ApiKeyDialog
                     setDropdownMenuOpen={setOpen}
-                    autoOpen={menuAction === "api-key"}
+                    autoOpen={autoOpenApiKey}
                 />
             </DropdownMenuContent>
         </DropdownMenu>

--- a/components/subscription/delete-subscription-dialog.tsx
+++ b/components/subscription/delete-subscription-dialog.tsx
@@ -19,13 +19,15 @@ import { Subscription } from "@/types/subscription";
 interface DeleteSubscriptionDialogProps {
     subscription: Subscription;
     onSuccess?: () => void;
+    autoOpen?: boolean;
 }
 
 export default function DeleteSubscriptionDialog({
     subscription,
     onSuccess,
+    autoOpen = false,
 }: DeleteSubscriptionDialogProps) {
-    const [open, setOpen] = useState(false);
+    const [open, setOpen] = useState(autoOpen);
     const t = useTranslations("SubscriptionPage");
     const [deletingSubscription, setDeletingSubscription] = useState(false);
 

--- a/components/subscription/delete-subscription-dialog.tsx
+++ b/components/subscription/delete-subscription-dialog.tsx
@@ -44,11 +44,13 @@ export default function DeleteSubscriptionDialog({
 
     return (
         <Dialog open={open} onOpenChange={setOpen}>
-            <DialogTrigger title={t("deleteSubscriptionDialog.title")}>
-                <div className="hover:bg-subflow-800 flex h-6 w-6 cursor-pointer items-center justify-center rounded-sm">
-                    <Trash2 size={16} strokeWidth={2} />
-                </div>
-            </DialogTrigger>
+            {!autoOpen && (
+                <DialogTrigger title={t("deleteSubscriptionDialog.title")}>
+                    <div className="hover:bg-subflow-800 flex h-6 w-6 cursor-pointer items-center justify-center rounded-sm">
+                        <Trash2 size={16} strokeWidth={2} />
+                    </div>
+                </DialogTrigger>
+            )}
             <DialogContent className="bg-subflow-900 border-subflow-100 w-120 rounded-2xl border-[3px] p-3 select-none sm:p-4">
                 <DialogHeader className="text-left">
                     <DialogTitle className="text-subflow-50 text-lg tracking-widest">


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI/UX change that adds query-parameter-driven dialog opening and minor not-found handling; no auth/data logic changes beyond invoking existing delete action.
> 
> **Overview**
> Adds deep-link style auto-opening for dialogs. `MoreMenu` now reads `?menu=api-key` to open the dropdown and passes `autoOpen` into `ApiKeyDialog`, which can start opened.
> 
> On the subscription page, `?action=delete&id=...` now auto-opens `DeleteSubscriptionDialog`, and the existing “subscription not found” toast is generalized to cover both `edit` and `delete` actions; the delete dialog hides its trigger when auto-opened.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c76396a8c0e11eb5e3d8537af1354890eba1a84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->