### PR TITLE
feat: add expandable item stack to cycle breakdown cards

### DIFF
--- a/components/subscription/chart-dialog-ui.tsx
+++ b/components/subscription/chart-dialog-ui.tsx
@@ -1,12 +1,6 @@
 "use client";
 
-import {
-    ComponentType,
-    ReactNode,
-    useEffect,
-    useId,
-    useState,
-} from "react";
+import { ComponentType, ReactNode, useEffect, useId, useState } from "react";
 import { useTranslations } from "next-intl";
 import { PieLabelRenderProps } from "recharts";
 import { ChevronDown, Repeat } from "lucide-react";

--- a/components/subscription/chart-dialog-ui.tsx
+++ b/components/subscription/chart-dialog-ui.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { ComponentType, ReactNode } from "react";
+import { ComponentType, ReactNode, useEffect, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
 import { PieLabelRenderProps } from "recharts";
-import { Repeat } from "lucide-react";
+import { ChevronDown, Repeat } from "lucide-react";
 
 import { subscriptionServices } from "@/data/subscriptionServices";
 import FormattedNumber from "@/components/subscription/formatted-number";
@@ -164,6 +164,39 @@ export const StatCard = ({
     </div>
 );
 
+type CycleItem = {
+    name: string;
+    serviceId: string;
+    amount: number;
+};
+
+const CYCLE_STACK_ICON_STYLES =
+    "bg-subflow-900 border-subflow-100 flex h-5 sm:h-7 w-5 sm:w-7 shrink-0 items-center justify-center rounded-sm sm:rounded-md border-2";
+
+const CycleStackIcon = ({
+    serviceId,
+    name,
+}: {
+    serviceId: string;
+    name: string;
+}) => {
+    const Icon = subscriptionServices.find(
+        (service) => service.uuid === serviceId,
+    )?.icon as ComponentType<{ className?: string }>;
+
+    return (
+        <div className={CYCLE_STACK_ICON_STYLES}>
+            {Icon ? (
+                <Icon className="h-3 w-3 sm:h-4 sm:w-4" />
+            ) : (
+                <span className="text-subflow-50 text-xs font-bold sm:text-lg">
+                    {name.charAt(0).toUpperCase()}
+                </span>
+            )}
+        </div>
+    );
+};
+
 export const CycleCard = ({
     label,
     count,
@@ -171,6 +204,7 @@ export const CycleCard = ({
     share,
     currency,
     subsLabel,
+    items,
 }: {
     label: string;
     count: number;
@@ -178,29 +212,137 @@ export const CycleCard = ({
     share: number;
     currency: string;
     subsLabel: string;
-}) => (
-    <div className="border-subflow-700/70 bg-subflow-800/50 flex min-w-0 flex-1 flex-col gap-3 rounded-lg border p-4">
-        <div className="flex items-center justify-between gap-3">
-            <span className="text-subflow-300 truncate text-xs tracking-wider">
-                {label}
-            </span>
-            <Repeat className="text-subflow-500 h-4 w-4 shrink-0" />
+    items: CycleItem[];
+}) => {
+    const [expanded, setExpanded] = useState(false);
+    const stackRef = useRef<HTMLDivElement>(null);
+    const [stackWidth, setStackWidth] = useState(0);
+    const [isSmUp, setIsSmUp] = useState(false);
+
+    useEffect(() => {
+        const el = stackRef.current;
+        if (!el) return;
+        setStackWidth(el.clientWidth);
+        if (typeof ResizeObserver === "undefined") return;
+        const observer = new ResizeObserver((entries) => {
+            const entry = entries[0];
+            if (entry) setStackWidth(entry.contentRect.width);
+        });
+        observer.observe(el);
+        return () => observer.disconnect();
+    }, []);
+
+    useEffect(() => {
+        if (typeof window === "undefined" || !window.matchMedia) return;
+        const mq = window.matchMedia("(min-width: 640px)");
+        const update = () => setIsSmUp(mq.matches);
+        update();
+        mq.addEventListener("change", update);
+        return () => mq.removeEventListener("change", update);
+    }, []);
+
+    // Match calendar-cell sizes: h-5/w-5 (mobile) → h-7/w-7 (sm+).
+    // Tailwind -space-x-1.5 = -6px overlap regardless of size.
+    const ICON = isSmUp ? 28 : 20;
+    const OVERLAP = 6;
+    const STEP = ICON - OVERLAP;
+    const BADGE = ICON; // +N badge matches icon size
+
+    const hasItems = items.length > 0;
+    const fullStackWidth = hasItems ? ICON + (items.length - 1) * STEP : 0;
+
+    let visibleCount = items.length;
+    if (stackWidth > 0 && fullStackWidth > stackWidth) {
+        // Reserve trailing badge (STEP wide after first icon).
+        visibleCount =
+            Math.floor((stackWidth - ICON - (BADGE - OVERLAP)) / STEP) + 1;
+        visibleCount = Math.max(0, visibleCount);
+        if (visibleCount >= items.length) visibleCount = items.length - 1;
+    }
+    const overflow = items.length - visibleCount;
+    const interactive = hasItems;
+
+    return (
+        <div className="border-subflow-700/70 bg-subflow-800/50 flex min-w-0 flex-1 flex-col gap-3 rounded-lg border p-4">
+            <div className="flex items-center justify-between gap-3">
+                <span className="text-subflow-300 truncate text-xs tracking-wider">
+                    {label}
+                </span>
+                <Repeat className="text-subflow-500 h-4 w-4 shrink-0" />
+            </div>
+            <div className="flex items-baseline gap-1">
+                <span className="text-subflow-50 text-2xl">{count}</span>
+                <span className="text-subflow-500 text-xs">{subsLabel}</span>
+            </div>
+            <div className="bg-subflow-700 h-1.5 rounded-full">
+                <div
+                    className="bg-subflow-200 h-1.5 rounded-full"
+                    style={{ width: `${share}%` }}
+                />
+            </div>
+            <div className="text-subflow-300 min-w-0 text-sm">
+                <FormattedNumber value={spend} /> {currency}
+            </div>
+            {interactive && (
+                <button
+                    type="button"
+                    onClick={() => setExpanded((v) => !v)}
+                    aria-expanded={expanded}
+                    aria-label={label}
+                    className="focus-visible:ring-subflow-300/80 -m-1 flex cursor-pointer items-center gap-2 rounded-md p-1 focus-visible:ring-2 focus-visible:outline-none"
+                >
+                    <div
+                        ref={stackRef}
+                        className="flex min-w-0 flex-1 items-center -space-x-1.5 overflow-hidden"
+                    >
+                        {items.slice(0, visibleCount).map((it, i) => (
+                            <CycleStackIcon
+                                key={`${it.serviceId}-${it.name}-${i}`}
+                                serviceId={it.serviceId}
+                                name={it.name}
+                            />
+                        ))}
+                        {overflow > 0 && (
+                            <div className={CYCLE_STACK_ICON_STYLES}>
+                                <span className="text-subflow-50 text-xs sm:text-sm">
+                                    +{overflow}
+                                </span>
+                            </div>
+                        )}
+                    </div>
+                    <ChevronDown
+                        className={`text-subflow-400 h-4 w-4 shrink-0 transition-transform ${
+                            expanded ? "rotate-180" : ""
+                        }`}
+                    />
+                </button>
+            )}
+            {interactive && expanded && (
+                <div className="border-subflow-700/70 flex flex-col gap-2 border-t pt-3">
+                    {items.map((it, i) => (
+                        <div
+                            key={`${it.serviceId}-${it.name}-${i}-row`}
+                            className="flex min-w-0 items-center justify-between gap-3"
+                        >
+                            <div className="flex min-w-0 items-center gap-2">
+                                <CycleStackIcon
+                                    serviceId={it.serviceId}
+                                    name={it.name}
+                                />
+                                <span className="text-subflow-100 truncate text-sm">
+                                    {it.name}
+                                </span>
+                            </div>
+                            <span className="text-subflow-300 shrink-0 text-xs">
+                                <FormattedNumber value={it.amount} /> {currency}
+                            </span>
+                        </div>
+                    ))}
+                </div>
+            )}
         </div>
-        <div className="flex items-baseline gap-1">
-            <span className="text-subflow-50 text-2xl">{count}</span>
-            <span className="text-subflow-500 text-xs">{subsLabel}</span>
-        </div>
-        <div className="bg-subflow-700 h-1.5 rounded-full">
-            <div
-                className="bg-subflow-200 h-1.5 rounded-full"
-                style={{ width: `${share}%` }}
-            />
-        </div>
-        <div className="text-subflow-300 min-w-0 text-sm">
-            <FormattedNumber value={spend} /> {currency}
-        </div>
-    </div>
-);
+    );
+};
 
 export const SectionHeader = ({
     title,

--- a/components/subscription/chart-dialog-ui.tsx
+++ b/components/subscription/chart-dialog-ui.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { ComponentType, ReactNode, useEffect, useRef, useState } from "react";
+import {
+    ComponentType,
+    ReactNode,
+    useCallback,
+    useEffect,
+    useId,
+    useState,
+} from "react";
 import { useTranslations } from "next-intl";
 import { PieLabelRenderProps } from "recharts";
 import { ChevronDown, Repeat } from "lucide-react";
@@ -164,7 +171,7 @@ export const StatCard = ({
     </div>
 );
 
-type CycleItem = {
+export type CycleItem = {
     name: string;
     serviceId: string;
     amount: number;
@@ -214,14 +221,20 @@ export const CycleCard = ({
     subsLabel: string;
     items: CycleItem[];
 }) => {
+    const t = useTranslations("SubscriptionPage");
+    const reactId = useId();
+    const panelId = `cycle-items-${reactId}`;
     const [expanded, setExpanded] = useState(false);
-    const stackRef = useRef<HTMLDivElement>(null);
     const [stackWidth, setStackWidth] = useState(0);
     const [isSmUp, setIsSmUp] = useState(false);
 
-    useEffect(() => {
-        const el = stackRef.current;
-        if (!el) return;
+    // Callback ref so the observer attaches whenever the stack node mounts
+    // (e.g., when items transition from empty to non-empty later on).
+    const stackRef = useCallback((el: HTMLDivElement | null) => {
+        if (!el) {
+            setStackWidth(0);
+            return;
+        }
         setStackWidth(el.clientWidth);
         if (typeof ResizeObserver === "undefined") return;
         const observer = new ResizeObserver((entries) => {
@@ -237,8 +250,13 @@ export const CycleCard = ({
         const mq = window.matchMedia("(min-width: 640px)");
         const update = () => setIsSmUp(mq.matches);
         update();
-        mq.addEventListener("change", update);
-        return () => mq.removeEventListener("change", update);
+        // Safari <14 only supports the legacy addListener/removeListener API.
+        if (typeof mq.addEventListener === "function") {
+            mq.addEventListener("change", update);
+            return () => mq.removeEventListener("change", update);
+        }
+        mq.addListener(update);
+        return () => mq.removeListener(update);
     }, []);
 
     // Match calendar-cell sizes: h-5/w-5 (mobile) → h-7/w-7 (sm+).
@@ -288,7 +306,13 @@ export const CycleCard = ({
                     type="button"
                     onClick={() => setExpanded((v) => !v)}
                     aria-expanded={expanded}
-                    aria-label={label}
+                    aria-controls={panelId}
+                    aria-label={t(
+                        expanded
+                            ? "chartDialog.cycleItemsCollapse"
+                            : "chartDialog.cycleItemsExpand",
+                        { label },
+                    )}
                     className="focus-visible:ring-subflow-300/80 -m-1 flex cursor-pointer items-center gap-2 rounded-md p-1 focus-visible:ring-2 focus-visible:outline-none"
                 >
                     <div
@@ -318,7 +342,10 @@ export const CycleCard = ({
                 </button>
             )}
             {interactive && expanded && (
-                <div className="border-subflow-700/70 flex flex-col gap-2 border-t pt-3">
+                <div
+                    id={panelId}
+                    className="border-subflow-700/70 flex flex-col gap-2 border-t pt-3"
+                >
                     {items.map((it, i) => (
                         <div
                             key={`${it.serviceId}-${it.name}-${i}-row`}

--- a/components/subscription/chart-dialog-ui.tsx
+++ b/components/subscription/chart-dialog-ui.tsx
@@ -3,7 +3,6 @@
 import {
     ComponentType,
     ReactNode,
-    useCallback,
     useEffect,
     useId,
     useState,
@@ -226,24 +225,23 @@ export const CycleCard = ({
     const panelId = `cycle-items-${reactId}`;
     const [expanded, setExpanded] = useState(false);
     const [stackWidth, setStackWidth] = useState(0);
+    const [stackEl, setStackEl] = useState<HTMLDivElement | null>(null);
     const [isSmUp, setIsSmUp] = useState(false);
 
-    // Callback ref so the observer attaches whenever the stack node mounts
-    // (e.g., when items transition from empty to non-empty later on).
-    const stackRef = useCallback((el: HTMLDivElement | null) => {
-        if (!el) {
-            setStackWidth(0);
-            return;
-        }
-        setStackWidth(el.clientWidth);
-        if (typeof ResizeObserver === "undefined") return;
+    // Track the node via state so the observer effect re-attaches whenever the
+    // stack node mounts (e.g., items transitioning from empty to non-empty)
+    // and cleans up deterministically on unmount via useEffect. The observer
+    // fires once after observe() with the initial size, so we don't need to
+    // call setStackWidth synchronously here.
+    useEffect(() => {
+        if (!stackEl || typeof ResizeObserver === "undefined") return;
         const observer = new ResizeObserver((entries) => {
             const entry = entries[0];
             if (entry) setStackWidth(entry.contentRect.width);
         });
-        observer.observe(el);
+        observer.observe(stackEl);
         return () => observer.disconnect();
-    }, []);
+    }, [stackEl]);
 
     useEffect(() => {
         if (typeof window === "undefined" || !window.matchMedia) return;
@@ -316,7 +314,7 @@ export const CycleCard = ({
                     className="focus-visible:ring-subflow-300/80 -m-1 flex cursor-pointer items-center gap-2 rounded-md p-1 focus-visible:ring-2 focus-visible:outline-none"
                 >
                     <div
-                        ref={stackRef}
+                        ref={setStackEl}
                         className="flex min-w-0 flex-1 items-center -space-x-1.5 overflow-hidden"
                     >
                         {items.slice(0, visibleCount).map((it, i) => (

--- a/components/subscription/chart-dialog.tsx
+++ b/components/subscription/chart-dialog.tsx
@@ -55,6 +55,7 @@ import {
     InsightCard,
     tabBtnClass,
     modeBtnClass,
+    type CycleItem,
 } from "./chart-dialog-ui";
 
 type Tab = "breakdown" | "analytics";
@@ -232,11 +233,6 @@ export default function ChartDialog({
         let totalSpentEver = 0;
         let newThisYear = 0;
         let amortizedMonthly = 0;
-        type CycleItem = {
-            name: string;
-            serviceId: string;
-            amount: number;
-        };
         const cycles = {
             monthly: { count: 0, spend: 0, items: [] as CycleItem[] },
             quarterly: { count: 0, spend: 0, items: [] as CycleItem[] },
@@ -278,12 +274,17 @@ export default function ChartDialog({
 
             const cycleKey = sub.paymentCycle as keyof typeof cycles;
             if (cycleKey in cycles) {
+                // Round once per item and reuse for both the cycle total and
+                // the expanded list so the card spend always equals the sum of
+                // visible item amounts (avoids "sum of rounded != rounded sum"
+                // drift between the card and the expansion).
+                const itemAmount = Math.round(amortizedPrice);
                 cycles[cycleKey].count++;
-                cycles[cycleKey].spend += amortizedPrice;
+                cycles[cycleKey].spend += itemAmount;
                 cycles[cycleKey].items.push({
                     name: sub.name,
                     serviceId: sub.serviceId || "",
-                    amount: Math.round(amortizedPrice),
+                    amount: itemAmount,
                 });
             }
         }

--- a/components/subscription/chart-dialog.tsx
+++ b/components/subscription/chart-dialog.tsx
@@ -232,10 +232,15 @@ export default function ChartDialog({
         let totalSpentEver = 0;
         let newThisYear = 0;
         let amortizedMonthly = 0;
+        type CycleItem = {
+            name: string;
+            serviceId: string;
+            amount: number;
+        };
         const cycles = {
-            monthly: { count: 0, spend: 0 },
-            quarterly: { count: 0, spend: 0 },
-            yearly: { count: 0, spend: 0 },
+            monthly: { count: 0, spend: 0, items: [] as CycleItem[] },
+            quarterly: { count: 0, spend: 0, items: [] as CycleItem[] },
+            yearly: { count: 0, spend: 0, items: [] as CycleItem[] },
         };
 
         for (const sub of effectiveAllSubscriptions) {
@@ -275,21 +280,32 @@ export default function ChartDialog({
             if (cycleKey in cycles) {
                 cycles[cycleKey].count++;
                 cycles[cycleKey].spend += amortizedPrice;
+                cycles[cycleKey].items.push({
+                    name: sub.name,
+                    serviceId: sub.serviceId || "",
+                    amount: Math.round(amortizedPrice),
+                });
             }
         }
+
+        const sortByAmountDesc = (items: CycleItem[]) =>
+            [...items].sort((a, b) => b.amount - a.amount);
 
         const roundedCycles = {
             monthly: {
                 count: cycles.monthly.count,
                 spend: Math.round(cycles.monthly.spend),
+                items: sortByAmountDesc(cycles.monthly.items),
             },
             quarterly: {
                 count: cycles.quarterly.count,
                 spend: Math.round(cycles.quarterly.spend),
+                items: sortByAmountDesc(cycles.quarterly.items),
             },
             yearly: {
                 count: cycles.yearly.count,
                 spend: Math.round(cycles.yearly.spend),
+                items: sortByAmountDesc(cycles.yearly.items),
             },
         };
 
@@ -920,6 +936,7 @@ export default function ChartDialog({
                                     share={statsData.cycles.monthly.share}
                                     currency={currency}
                                     subsLabel={t("chartDialog.subs")}
+                                    items={statsData.cycles.monthly.items}
                                 />
                                 <CycleCard
                                     label={t("quarterly")}
@@ -928,6 +945,7 @@ export default function ChartDialog({
                                     share={statsData.cycles.quarterly.share}
                                     currency={currency}
                                     subsLabel={t("chartDialog.subs")}
+                                    items={statsData.cycles.quarterly.items}
                                 />
                                 <CycleCard
                                     label={t("yearly")}
@@ -936,6 +954,7 @@ export default function ChartDialog({
                                     share={statsData.cycles.yearly.share}
                                     currency={currency}
                                     subsLabel={t("chartDialog.subs")}
+                                    items={statsData.cycles.yearly.items}
                                 />
                             </div>
                         </div>

--- a/messages/en.json
+++ b/messages/en.json
@@ -136,6 +136,8 @@
             "deltaFlatDescription": "Estimated spend is close to last month.",
             "cycleBreakdownDescription": "Amounts use monthly equivalent cost so billing cycles stay comparable.",
             "subs": "subs",
+            "cycleItemsExpand": "Expand {label} subscriptions list",
+            "cycleItemsCollapse": "Collapse {label} subscriptions list",
             "annualUpgradeHint": "Consider Annual Plan",
             "annualUpgradeHintDescription": "{count} subscription(s) have been on monthly or quarterly billing for over a year — switching to annual may reduce your total spend.",
             "annualUpgradeHintNoneDescription": "No monthly or quarterly subscriptions have been running for more than 12 months."

--- a/messages/es.json
+++ b/messages/es.json
@@ -136,6 +136,8 @@
             "deltaFlatDescription": "El gasto estimado está cerca del mes anterior.",
             "cycleBreakdownDescription": "Los importes usan costo mensual equivalente para comparar ciclos de pago.",
             "subs": "subs",
+            "cycleItemsExpand": "Expandir lista de suscripciones de {label}",
+            "cycleItemsCollapse": "Contraer lista de suscripciones de {label}",
             "annualUpgradeHint": "Considerar plan anual",
             "annualUpgradeHintDescription": "{count} suscripción(es) llevan más de un año en ciclo mensual o trimestral — cambiar a anual podría reducir el gasto total.",
             "annualUpgradeHintNoneDescription": "No hay suscripciones mensuales o trimestrales con más de 12 meses de antigüedad."

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -136,6 +136,8 @@
             "deltaFlatDescription": "今月の見込み支出は前月とほぼ同じです。",
             "cycleBreakdownDescription": "金額は月額換算で表示し、支払いサイクルを比較しやすくしています。",
             "subs": "件",
+            "cycleItemsExpand": "{label}のサブスク一覧を展開",
+            "cycleItemsCollapse": "{label}のサブスク一覧を折りたたむ",
             "annualUpgradeHint": "年払いへの切り替えを検討",
             "annualUpgradeHintDescription": "{count}件のサブスクが月払い・四半期払いで1年以上継続中。年払いに切り替えると費用を抑えられる場合があります。",
             "annualUpgradeHintNoneDescription": "月払いまたは四半期払いで12か月以上のサブスクはありません。"

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -136,6 +136,8 @@
             "deltaFlatDescription": "本月預估花費與上月相近。",
             "cycleBreakdownDescription": "金額以每月等效成本呈現，方便比較付款週期。",
             "subs": "筆",
+            "cycleItemsExpand": "展開{label}的訂閱清單",
+            "cycleItemsCollapse": "收合{label}的訂閱清單",
             "annualUpgradeHint": "考慮切換年訂閱",
             "annualUpgradeHintDescription": "{count} 個訂閱已以月付或季付超過一年，切換年訂閱可能降低總花費。",
             "annualUpgradeHintNoneDescription": "目前沒有月付或季付訂閱超過 12 個月。"


### PR DESCRIPTION
## Summary
- 在訂閱分析的「付款週期分布」卡片下方新增訂閱項目的圖示堆疊（calendar 風格的 icon stack），超出寬度時顯示 `+N` 徽章
- 點擊堆疊可展開該週期的詳細清單，顯示訂閱名稱與每月等效金額
- 使用 `ResizeObserver` + `matchMedia` 動態計算可見 icon 數，RWD 自動對齊行動／桌面尺寸

## Test plan
- [ ] 開啟訂閱分析 → 分析頁，確認三張週期卡片下方顯示 icon stack
- [ ] 視窗縮放時 `+N` 數字會跟著重算
- [ ] 點擊堆疊可展開／收合，chevron 同步旋轉
- [ ] 行動寬度與 sm+ 寬度下 icon 尺寸與重疊樣式與日曆格子一致
- [ ] 訂閱數為 0 時不顯示堆疊按鈕

🤖 Generated with [Claude Code](https://claude.com/claude-code)